### PR TITLE
Chrome 61 supports modules out-of-the-box

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Will work in your browser in these cases:
 
 <ul>
 <li>Safari 10.1.</li>
-<li>Chrome Canary 60 – behind the Experimental Web Platform flag in <code>chrome:flags</code>.</li>
+<li>Chrome 61.</li>
 <li>Firefox 54 – behind the <code>dom.moduleScripts.enabled</code> setting in <code>about:config</code>.</li>
 <li>Edge 15 – behind the Experimental JavaScript Features setting in <code>about:flags</code>.</li>
 </ul>


### PR DESCRIPTION
Now stable, no more flags needed